### PR TITLE
DEV-1444 Make prefetch count configurable

### DIFF
--- a/app/services/rabbit.py
+++ b/app/services/rabbit.py
@@ -33,6 +33,7 @@ class RabbitClient:
         )
 
         self.channel = self.connection.channel()
+        self.prefetch_count = int(self.rabbitConfig["prefetch_count"])
 
     def send_message(self, routing_key, body, exchange=""):
         try:
@@ -51,6 +52,9 @@ class RabbitClient:
                 try:
                     channel = self.connection.channel()
 
+                    channel.basic_qos(
+                        prefetch_count=self.prefetch_count, global_qos=False
+                    )
                     channel.basic_consume(
                         queue=queue, on_message_callback=on_message_callback
                     )

--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,7 @@ app:
         queue: !ENV ${RABBITMQ_QUEUE}
         exchange: !ENV ${RABBITMQ_EXCHANGE}
         get_subtitles_routing_key: !ENV ${RABBITMQ_GET_SUBTITLES_ROUTING_KEY}
+        prefetch_count: !ENV ${RABBITMQ_PREFETCH_COUNT}
     mtd-transformer: 
         host: !ENV ${MTD_TRANSFORMER}
         transformation: OR-rf5kf25

--- a/conftest.py
+++ b/conftest.py
@@ -15,4 +15,5 @@ def env_setup(monkeypatch):
     monkeypatch.setenv("RABBITMQ_QUEUE", "queue")
     monkeypatch.setenv("RABBITMQ_EXCHANGE", "exchange")
     monkeypatch.setenv("RABBITMQ_GET_SUBTITLES_ROUTING_KEY", "routingkey")
+    monkeypatch.setenv("RABBITMQ_PREFETCH_COUNT", "1")
     monkeypatch.setenv("MTD_TRANSFORMER", "url")


### PR DESCRIPTION
As default, the prefetch count is unlimited, meaning that it will send
as many messages to a single consumer as it appears ready to accept them.
Making the prefetch count configurable allows for effectively distributing
the workload.