### PR TITLE
DEV-1426 Use lores if hires is unavailable

### DIFF
--- a/tests/helpers/test_events_parser.py
+++ b/tests/helpers/test_events_parser.py
@@ -14,11 +14,11 @@ INVALID_METADATA_RESPONSE_EVENTS = [
     "getMetadataResponseSocAfterEom",
     "getMetadataResponseSomMissing",
     "getMetadataResponseMalformedTimecode",
-    "getMetadataResponseHiresMissing",
     "getMetadataResponseMediaIDMissing",
     "getMetadataResponseInvalidTimecode",
     "getMetadataResponseWrongRootTag",
     "invalidXml",
+    "getMetadataResponseHiresAndLoresMissing",
 ]
 
 VALID_METADATA_RESPONSE_EVENTS = [
@@ -28,6 +28,7 @@ VALID_METADATA_RESPONSE_EVENTS = [
     "getMetadataResponseSOMSOCEOC",
     "getMetadataResponseWithWhitespace",
     "getMetadataResponseAudio",
+    "getMetadataResponseHiresMissing",
 ]
 
 VALID_TIMECODES = [
@@ -51,6 +52,11 @@ INVALID_TIMECODES = [
     "-5:00:00:02",
     "01:-03:03:04",
     "Ik heb zin in een zin, maar heeft deze zin wel zin?",
+]
+
+CALCULATE_RESOLUTION_XPATH_EVENTS = [
+    ("getMetadataResponse", "hires"),
+    ("getMetadataResponseHiresMissing", "lores"),
 ]
 
 
@@ -161,3 +167,20 @@ def test_invalid_timecode_to_frames(timecode):
     # ACT
     with pytest.raises(InvalidEventException):
         event.metadata._VideoMetadata__timecode_to_frames(timecode[0], timecode[1])
+
+
+@pytest.mark.parametrize("event, res", CALCULATE_RESOLUTION_XPATH_EVENTS)
+def test_parse_calculate_resolution_xpath(event, res):
+    # ARRANGE
+    xml = resources.load_xml_resource(event)
+    event_parser = EventParser()
+
+    # ACT
+    event_parser.event = event_parser._parse_event("getMetadataResponse", xml)
+    resolution = event_parser._calculate_resolution_xpath()
+
+    # ASSERT
+    
+    assert resolution == (
+        f"//ebu:format[@formatDefinition='current'][./ebu:videoFormat[@videoFormatDefinition='{res}']]"
+    )

--- a/tests/resources/getMetadataResponseHiresAndLoresMissing.xml
+++ b/tests/resources/getMetadataResponseHiresAndLoresMissing.xml
@@ -3,7 +3,7 @@
   xmlns:ns2="http://www.vrt.be/mig/viaa/api" 
   xmlns:ns3="http://purl.org/dc/elements/1.1/" 
   xmlns:ns4="urn:ebu:metadata-schema:ebuCore_2012">
-  <ns2:correlationId>test_correlation</ns2:correlationId>
+  <ns2:correlationId>123</ns2:correlationId>
   <ns2:timestamp>2019-09-24T17:21:28.787+02:00</ns2:timestamp>
   <ns2:status>SUCCESS</ns2:status>
   <ns2:metadata>
@@ -97,31 +97,8 @@
       <ns4:genre typeDefinition=""/>
       <ns4:objectType typeDefinition="footage"/>
     </ns4:type>
-    <ns4:format formatDefinition="current">
-      <ns4:videoFormat videoFormatDefinition="lores">
-        <ns4:width>1280</ns4:width>
-        <ns4:height>720</ns4:height>
-        <ns4:frameRate>25</ns4:frameRate>
-        <ns4:aspectRatio>
-          <ns4:factorNumerator>16</ns4:factorNumerator>
-          <ns4:factorDenominator>9</ns4:factorDenominator>
-        </ns4:aspectRatio>
-        <ns4:codec>
-          <ns4:name>H264</ns4:name>
-        </ns4:codec>
-        <ns4:bitRate>2668816</ns4:bitRate>
-      </ns4:videoFormat>
-      <ns4:containerFormat formatDefinition="MP4"/>
-      <ns4:start>
-        <ns4:timecode>00:00:00:00</ns4:timecode>
-      </ns4:start>
-      <ns4:end>
-        <ns4:timecode>00:03:24:21</ns4:timecode>
-      </ns4:end>
-      <ns4:technicalAttributeString typeDefinition="SOM">00:00:00:00</ns4:technicalAttributeString>
-    </ns4:format>
     <ns4:identifier typeDefinition="MEDIA_ID">
-      <ns3:identifier>TEST_ID</ns3:identifier>
+      <ns3:identifier>AIM10048454</ns3:identifier>
       <ns4:attributor>
         <ns4:organisationDetails>
           <ns4:organisationName>AIM</ns4:organisationName>


### PR DESCRIPTION
Normally both hires and lores information is present in the incoming metadata.
In that case, the hires information will be used. However, in some cases, only
the lores information is available. Instead of raising an invalid event it
should use that lores information.