### PR TITLE
DEV-1469 remove timestamp workaround

### DIFF
--- a/app/helpers/events_parser.py
+++ b/app/helpers/events_parser.py
@@ -21,7 +21,7 @@ class EventParser(object):
         media_type = self._get_media_type()
         metadata = self._parse_metadata(media_type)
 
-        timestamp = self._get_xpath_from_event("./vrt:timestamp", optional=True)
+        timestamp = self._get_xpath_from_event("./vrt:timestamp")
 
         if event_type == "getMetadataResponse":
             correlation_id = self._get_xpath_from_event("./vrt:correlationId")

--- a/tests/resources/getMetadataResponseWithClosedOT.xml
+++ b/tests/resources/getMetadataResponseWithClosedOT.xml
@@ -1,62 +1,65 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<viaa:getMetadataResponse xmlns:viaa="http://www.vrt.be/mig/viaa/api" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ns4="http://www.vrt.be/mig/viaa">
-  <viaa:correlationId>WP00026602</viaa:correlationId>
+<viaa:getMetadataResponse xmlns:viaa="http://www.vrt.be/mig/viaa/api"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012"
+  xmlns:ns4="http://www.vrt.be/mig/viaa">
+  <viaa:timestamp>2021-02-18T17:40:21.180+01:00</viaa:timestamp>
+  <viaa:correlationId>WP00181540</viaa:correlationId>
   <viaa:status>SUCCESS</viaa:status>
   <viaa:metadata>
     <ebu:title>
-      <dc:title>Witse R004 A0006</dc:title>
+      <dc:title>Winteruur R006 A0022</dc:title>
     </ebu:title>
     <ebu:alternativeTitle>
-      <dc:title>Duivelskoppel</dc:title>
+      <dc:title>Koen De Bouw</dc:title>
     </ebu:alternativeTitle>
     <ebu:alternativeTitle typeDefinition="season">
-      <dc:title>Witse R004</dc:title>
+      <dc:title>Winteruur R006</dc:title>
     </ebu:alternativeTitle>
     <ebu:alternativeTitle typeDefinition="series">
-      <dc:title>Witse</dc:title>
+      <dc:title>Winteruur</dc:title>
     </ebu:alternativeTitle>
     <ebu:alternativeTitle typeDefinition="program">
-      <dc:title>Witse R004 A0006</dc:title>
+      <dc:title>Winteruur R006 A0022</dc:title>
     </ebu:alternativeTitle>
     <ebu:creator>
       <ebu:organisationDetails>
-        <ebu:organisationName>TV</ebu:organisationName>
+        <ebu:organisationName>Panenka</ebu:organisationName>
       </ebu:organisationDetails>
-      <ebu:role typeDefinition="productionCompany" />
+      <ebu:role typeDefinition="productionCompany"/>
     </ebu:creator>
     <ebu:creator>
       <ebu:organisationDetails>
-        <ebu:organisationName />
+        <ebu:organisationName/>
       </ebu:organisationDetails>
-      <ebu:role typeDefinition="provenance" />
+      <ebu:role typeDefinition="provenance"/>
     </ebu:creator>
-    <ebu:subject note="" />
+    <ebu:subject note="STUDIOGAST, HOND, VOORDRACHT, BOEK, DE BOUW KOEN"/>
     <ebu:description typeDefinition="short">
-      <dc:description>Vlaamse misdaadserie rond een eigenzinnige en gedreven speurder bij de Federale Recherche in Halle.</dc:description>
+      <dc:description>Wim Helsen nodigt interessante gasten uit voor een gesprek over hun favoriete tekst.</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="long">
-      <dc:description>De rijke barones Van Calster wordt bij een inbraak vermoord, maar vreemd genoeg worden maar weinig zaken gestolen in haar kasteel. De barones had een veel jongere minnaar, de zogezegde landjonker Hendrik Palfijn, en leefde in onmin met haar zoon Didier. Beide mannen azen op het bezit van de barone, en delen een interesse in Sylvia, een model uit het Oostblok dat het in het Westen wil 'maken'.</dc:description>
+      <dc:description>Gast: Koen De Bouw
+
+Koen De Bouw kiest voor een tekst uit 'De boer die sterft' van Karel van de Woestijne.</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="season">
-      <dc:description>4</dc:description>
+      <dc:description>6</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="comment">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="cast">
-      <dc:description>
-        Met: Hubert Damen (Witse), Inge Paulussen (Sam Deconinck), Daan Hugaert (Romain Van Deun), Marc Stroobants (Rudy Dams), Dirk Tuypens (Peter Wijtinckx), Els Olaerts (Annemie Nachtegaele) e.a.
-        Gastacteurs: Katelijne Verbeke (Dokter Véronique Maes), Roel Vanderstukken (Kris), Kristine Van Pellicom (Hazel Ruysselede), Rita Smets (Angèle Van Calster), Gene Bervoets (Hendrik Palfijn), Robert De La Haye (Didier Van Calster) e.a.
-      </dc:description>
+      <dc:description>Helsen Wim</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="category">
       <dc:description>algemeen</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="categoryTrailer">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="productionMethod">
-      <dc:description>intern</dc:description>
+      <dc:description>extern</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="status">
       <dc:description>gearchiveerd</dc:description>
@@ -71,36 +74,60 @@
       <dc:description>false</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="historicalFormat">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="duration">
-      <dc:description>00:55:14:00</dc:description>
+      <dc:description>00:13:18:10</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="rights">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="rightsType">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:publisher>
       <ebu:organisationDetails>
-        <ebu:organisationName />
+        <ebu:organisationName/>
       </ebu:organisationDetails>
-      <ebu:role typeDefinition="publisher" />
+      <ebu:role typeDefinition="publisher"/>
     </ebu:publisher>
+    <ebu:contributor>
+      <ebu:contactDetails>
+        <ebu:name>Helsen Wim</ebu:name>
+      </ebu:contactDetails>
+      <ebu:role typeDefinition="presenter"/>
+    </ebu:contributor>
+    <ebu:contributor>
+      <ebu:contactDetails>
+        <ebu:name>Van Hove Annemie</ebu:name>
+      </ebu:contactDetails>
+      <ebu:role typeDefinition="producer"/>
+    </ebu:contributor>
+    <ebu:contributor>
+      <ebu:contactDetails>
+        <ebu:name>Vanderlinden Katrien</ebu:name>
+      </ebu:contactDetails>
+      <ebu:role typeDefinition="director"/>
+    </ebu:contributor>
+    <ebu:contributor>
+      <ebu:contactDetails>
+        <ebu:name>Couvreur Walter</ebu:name>
+      </ebu:contactDetails>
+      <ebu:role typeDefinition="onbepaald"/>
+    </ebu:contributor>
     <ebu:date>
-      <ebu:created />
-      <ebu:alternative startDate="2020-08-04" startTime="00:00:00" typeDefinition="mainDate" />
+      <ebu:created/>
+      <ebu:alternative startDate="2020-12-08" startTime="00:00:00" typeDefinition="mainDate"/>
     </ebu:date>
     <ebu:type>
-      <ebu:genre typeDefinition="fictie" />
-      <ebu:objectType typeDefinition="program" />
+      <ebu:genre typeDefinition="magazine"/>
+      <ebu:objectType typeDefinition="program"/>
     </ebu:type>
     <ebu:format formatDefinition="current">
       <ebu:videoFormat videoFormatDefinition="hires">
         <ebu:width>1920</ebu:width>
         <ebu:height>1080</ebu:height>
-        <ebu:frameRate>25</ebu:frameRate>
+        <ebu:frameRate factorDenominator="1" factorNumerator="25">25</ebu:frameRate>
         <ebu:aspectRatio>
           <ebu:factorNumerator>16</ebu:factorNumerator>
           <ebu:factorDenominator>9</ebu:factorDenominator>
@@ -110,20 +137,20 @@
         </ebu:codec>
         <ebu:bitRate>113664000</ebu:bitRate>
       </ebu:videoFormat>
-      <ebu:containerFormat formatDefinition="MXF OP1a" />
+      <ebu:containerFormat formatDefinition="MXF OP1a"/>
       <ebu:start>
-        <ebu:timecode>00:03:00:00</ebu:timecode>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
       </ebu:start>
       <ebu:end>
-        <ebu:timecode>00:58:14:00</ebu:timecode>
+        <ebu:timecode>10:13:18:10</ebu:timecode>
       </ebu:end>
-      <ebu:technicalAttributeString typeDefinition="SOM">00:03:00:00</ebu:technicalAttributeString>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
     </ebu:format>
     <ebu:format formatDefinition="current">
       <ebu:videoFormat videoFormatDefinition="lores">
         <ebu:width>1280</ebu:width>
         <ebu:height>720</ebu:height>
-        <ebu:frameRate>25</ebu:frameRate>
+        <ebu:frameRate factorDenominator="1" factorNumerator="25">25</ebu:frameRate>
         <ebu:aspectRatio>
           <ebu:factorNumerator>16</ebu:factorNumerator>
           <ebu:factorDenominator>9</ebu:factorDenominator>
@@ -131,43 +158,84 @@
         <ebu:codec>
           <ebu:name>H264</ebu:name>
         </ebu:codec>
-        <ebu:bitRate>2106680</ebu:bitRate>
+        <ebu:bitRate>3250432</ebu:bitRate>
       </ebu:videoFormat>
-      <ebu:containerFormat formatDefinition="MP4" />
+      <ebu:containerFormat formatDefinition="MP4"/>
       <ebu:start>
-        <ebu:timecode>00:03:00:00</ebu:timecode>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
       </ebu:start>
       <ebu:end>
-        <ebu:timecode>00:58:14:00</ebu:timecode>
+        <ebu:timecode>10:13:18:10</ebu:timecode>
       </ebu:end>
-      <ebu:technicalAttributeString typeDefinition="SOM">00:03:00:00</ebu:technicalAttributeString>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
     </ebu:format>
+    <ebu:format formatDefinition="current">
+      <ebu:dataFormat>
+        <ebu:captioningFormat formatDefinition="closed" language="nl"/>
+      </ebu:dataFormat>
+      <ebu:start>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
+      </ebu:start>
+      <ebu:end>
+        <ebu:timecode>10:13:18:10</ebu:timecode>
+      </ebu:end>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
+      <ebu:dateCreated startDate="2020-12-04" startTime="11:57:35"/>
+      <ebu:dateModified startDate="2020-12-04" startTime="11:57:35"/>
+    </ebu:format>
+    <ebu:identifier typeDefinition="historicalRecordNumber">
+      <dc:identifier/>
+    </ebu:identifier>
     <ebu:identifier typeDefinition="MEDIA_ID">
-      <dc:identifier>WP00026602</dc:identifier>
+      <dc:identifier>WP00181540</dc:identifier>
       <ebu:attributor>
         <ebu:organisationDetails>
           <ebu:organisationName>WON</ebu:organisationName>
         </ebu:organisationDetails>
       </ebu:attributor>
     </ebu:identifier>
-    <ebu:identifier typeDefinition="historicalRecordNumber">
-      <dc:identifier />
-    </ebu:identifier>
     <ebu:identifier formatLanguage="NL" typeDefinition="otIdClosed">
-      <dc:identifier />
+      <dc:identifier/>
     </ebu:identifier>
-    <ebu:relation internalRunningOrderNumber="6" typeDefinition="season" />
+    <ebu:relation internalRunningOrderNumber="22" typeDefinition="season"/>
+    <ebu:relation typeDefinition="Programma verwijst naar trailer">
+      <ebu:relationIdentifier>
+        <dc:identifier>WTC20502_00185545</dc:identifier>
+      </ebu:relationIdentifier>
+    </ebu:relation>
     <ebu:relation typeDefinition="season">
       <ebu:relationIdentifier>
-        <dc:identifier>4488222529</dc:identifier>
+        <dc:identifier>922552729527</dc:identifier>
       </ebu:relationIdentifier>
     </ebu:relation>
     <ebu:rights>
       <ebu:rightsHolder>
         <ebu:organisationDetails>
-          <ebu:organisationName />
+          <ebu:organisationName/>
         </ebu:organisationDetails>
       </ebu:rightsHolder>
     </ebu:rights>
+    <ebu:publicationHistory>
+      <ebu:publicationEvent>
+        <ebu:publicationDate>2020-12-09</ebu:publicationDate>
+        <ebu:publicationTime>00:00:00</ebu:publicationTime>
+        <ebu:publicationChannel typeDefinition="TV" typeLabel="CANVAS"/>
+      </ebu:publicationEvent>
+      <ebu:publicationEvent>
+        <ebu:publicationDate>2020-12-08</ebu:publicationDate>
+        <ebu:publicationTime>00:00:00</ebu:publicationTime>
+        <ebu:publicationChannel typeDefinition="TV" typeLabel="CANVAS"/>
+      </ebu:publicationEvent>
+      <ebu:publicationEvent>
+        <ebu:publicationDate>2020-12-08</ebu:publicationDate>
+        <ebu:publicationTime>00:00:00</ebu:publicationTime>
+        <ebu:publicationChannel typeDefinition="VRTNU" typeLabel="Onbepaald"/>
+      </ebu:publicationEvent>
+      <ebu:publicationEvent>
+        <ebu:publicationDate>2020-12-08</ebu:publicationDate>
+        <ebu:publicationTime>00:00:00</ebu:publicationTime>
+        <ebu:publicationChannel typeDefinition="VRTNU" typeLabel="Onbepaald"/>
+      </ebu:publicationEvent>
+    </ebu:publicationHistory>
   </viaa:metadata>
 </viaa:getMetadataResponse>

--- a/tests/resources/getMetadataResponseWithOpenOT.xml
+++ b/tests/resources/getMetadataResponseWithOpenOT.xml
@@ -3,107 +3,105 @@
   xmlns:dc="http://purl.org/dc/elements/1.1/"
   xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012"
   xmlns:ns4="http://www.vrt.be/mig/viaa">
-  <viaa:correlationId>WP00026602</viaa:correlationId>
+  <viaa:timestamp>2021-02-18T10:18:20.742+01:00</viaa:timestamp>
+  <viaa:correlationId>WP00193065</viaa:correlationId>
   <viaa:status>SUCCESS</viaa:status>
   <viaa:metadata>
     <ebu:title>
-      <dc:title>Witse R004 A0006</dc:title>
+      <dc:title>Podium 19 R001 A0054</dc:title>
     </ebu:title>
     <ebu:alternativeTitle>
-      <dc:title>Duivelskoppel</dc:title>
+      <dc:title>Amenra  - A Flood of Light</dc:title>
     </ebu:alternativeTitle>
     <ebu:alternativeTitle typeDefinition="season">
-      <dc:title>Witse R004</dc:title>
+      <dc:title>Podium 19 R001</dc:title>
     </ebu:alternativeTitle>
     <ebu:alternativeTitle typeDefinition="series">
-      <dc:title>Witse</dc:title>
+      <dc:title>Podium 19</dc:title>
     </ebu:alternativeTitle>
     <ebu:alternativeTitle typeDefinition="program">
-      <dc:title>Witse R004 A0006</dc:title>
+      <dc:title>Podium 19 R001 A0054</dc:title>
     </ebu:alternativeTitle>
     <ebu:creator>
       <ebu:organisationDetails>
-        <ebu:organisationName>TV</ebu:organisationName>
+        <ebu:organisationName>EPRO</ebu:organisationName>
       </ebu:organisationDetails>
-      <ebu:role typeDefinition="productionCompany" />
+      <ebu:role typeDefinition="productionCompany"/>
     </ebu:creator>
     <ebu:creator>
       <ebu:organisationDetails>
-        <ebu:organisationName />
+        <ebu:organisationName/>
       </ebu:organisationDetails>
-      <ebu:role typeDefinition="provenance" />
+      <ebu:role typeDefinition="provenance"/>
     </ebu:creator>
-    <ebu:subject note="" />
+    <ebu:subject note=""/>
     <ebu:description typeDefinition="short">
-      <dc:description>Vlaamse misdaadserie rond een eigenzinnige en gedreven speurder bij de Federale Recherche in Halle.</dc:description>
+      <dc:description>Podium 19 is een initiatief van de Vlaamse Kunstinstellingen om een breed cultuuraanbod uit te zenden: een gezamenlijke, virtuele zaal waar, zolang die zalen de impact van het coronavirus voelen, nieuwe producties uit de vele Vlaamse cultuurhuizen aan het publiek getoond zullen worden.</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="long">
-      <dc:description>De rijke barones Van Calster wordt bij een inbraak vermoord, maar vreemd genoeg worden maar weinig zaken gestolen in haar kasteel. De barones had een veel jongere minnaar, de zogezegde landjonker Hendrik Palfijn, en leefde in onmin met haar zoon Didier. Beide mannen azen op het bezit van de barone, en delen een interesse in Sylvia, een model uit het Oostblok dat het in het Westen wil 'maken'.</dc:description>
+      <dc:description>Een indringende kijk in de wereld van de Belgische post-metalband Amenra naar aanleiding van zijn twintigste verjaardag.</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="season">
-      <dc:description>4</dc:description>
+      <dc:description>1</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="comment">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="cast">
-      <dc:description>
-        Met: Hubert Damen (Witse), Inge Paulussen (Sam Deconinck), Daan Hugaert (Romain Van Deun), Marc Stroobants (Rudy Dams), Dirk Tuypens (Peter Wijtinckx), Els Olaerts (Annemie Nachtegaele) e.a.
-        Gastacteurs: Katelijne Verbeke (Dokter Véronique Maes), Roel Vanderstukken (Kris), Kristine Van Pellicom (Hazel Ruysselede), Rita Smets (Angèle Van Calster), Gene Bervoets (Hendrik Palfijn), Robert De La Haye (Didier Van Calster) e.a.
-      </dc:description>
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="category">
       <dc:description>algemeen</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="categoryTrailer">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="productionMethod">
-      <dc:description>intern</dc:description>
+      <dc:description>extern</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="status">
-      <dc:description>gearchiveerd</dc:description>
+      <dc:description>nieuw</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="cleanMediaVersion">
-      <dc:description>0</dc:description>
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="hasBeenBroadcasted">
-      <dc:description>true</dc:description>
+      <dc:description>false</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="contentCheck">
       <dc:description>false</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="historicalFormat">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="duration">
-      <dc:description>00:55:14:00</dc:description>
+      <dc:description>01:39:34:21</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="rights">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="rightsType">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:publisher>
       <ebu:organisationDetails>
-        <ebu:organisationName />
+        <ebu:organisationName/>
       </ebu:organisationDetails>
-      <ebu:role typeDefinition="publisher" />
+      <ebu:role typeDefinition="publisher"/>
     </ebu:publisher>
     <ebu:date>
-      <ebu:created />
-      <ebu:alternative startDate="2020-08-04" startTime="00:00:00" typeDefinition="mainDate" />
+      <ebu:created/>
+      <ebu:alternative startDate="2021-02-18" startTime="00:00:00" typeDefinition="mainDate"/>
     </ebu:date>
     <ebu:type>
-      <ebu:genre typeDefinition="fictie" />
-      <ebu:objectType typeDefinition="program" />
+      <ebu:genre typeDefinition="podium"/>
+      <ebu:objectType typeDefinition="program"/>
     </ebu:type>
     <ebu:format formatDefinition="current">
       <ebu:videoFormat videoFormatDefinition="hires">
         <ebu:width>1920</ebu:width>
         <ebu:height>1080</ebu:height>
-        <ebu:frameRate>25</ebu:frameRate>
+        <ebu:frameRate factorDenominator="1" factorNumerator="25">25</ebu:frameRate>
         <ebu:aspectRatio>
           <ebu:factorNumerator>16</ebu:factorNumerator>
           <ebu:factorDenominator>9</ebu:factorDenominator>
@@ -113,20 +111,20 @@
         </ebu:codec>
         <ebu:bitRate>113664000</ebu:bitRate>
       </ebu:videoFormat>
-      <ebu:containerFormat formatDefinition="MXF OP1a" />
+      <ebu:containerFormat formatDefinition="MXF OP1a"/>
       <ebu:start>
-        <ebu:timecode>00:03:00:00</ebu:timecode>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
       </ebu:start>
       <ebu:end>
-        <ebu:timecode>00:58:14:00</ebu:timecode>
+        <ebu:timecode>11:39:34:21</ebu:timecode>
       </ebu:end>
-      <ebu:technicalAttributeString typeDefinition="SOM">00:03:00:00</ebu:technicalAttributeString>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
     </ebu:format>
     <ebu:format formatDefinition="current">
       <ebu:videoFormat videoFormatDefinition="lores">
         <ebu:width>1280</ebu:width>
         <ebu:height>720</ebu:height>
-        <ebu:frameRate>25</ebu:frameRate>
+        <ebu:frameRate factorDenominator="1" factorNumerator="25">25</ebu:frameRate>
         <ebu:aspectRatio>
           <ebu:factorNumerator>16</ebu:factorNumerator>
           <ebu:factorDenominator>9</ebu:factorDenominator>
@@ -134,43 +132,64 @@
         <ebu:codec>
           <ebu:name>H264</ebu:name>
         </ebu:codec>
-        <ebu:bitRate>2106680</ebu:bitRate>
+        <ebu:bitRate>1649720</ebu:bitRate>
       </ebu:videoFormat>
-      <ebu:containerFormat formatDefinition="MP4" />
+      <ebu:containerFormat formatDefinition="MP4"/>
       <ebu:start>
-        <ebu:timecode>00:03:00:00</ebu:timecode>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
       </ebu:start>
       <ebu:end>
-        <ebu:timecode>00:58:14:00</ebu:timecode>
+        <ebu:timecode>11:39:34:21</ebu:timecode>
       </ebu:end>
-      <ebu:technicalAttributeString typeDefinition="SOM">00:03:00:00</ebu:technicalAttributeString>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
     </ebu:format>
+    <ebu:format formatDefinition="current">
+      <ebu:dataFormat>
+        <ebu:captioningFormat formatDefinition="open" language="nl"/>
+      </ebu:dataFormat>
+      <ebu:start>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
+      </ebu:start>
+      <ebu:end>
+        <ebu:timecode>11:39:34:21</ebu:timecode>
+      </ebu:end>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
+      <ebu:dateCreated startDate="2021-02-17" startTime="12:34:45"/>
+      <ebu:dateModified startDate="2021-02-17" startTime="13:09:34"/>
+    </ebu:format>
+    <ebu:identifier typeDefinition="historicalRecordNumber">
+      <dc:identifier/>
+    </ebu:identifier>
     <ebu:identifier typeDefinition="MEDIA_ID">
-      <dc:identifier>WP00026602</dc:identifier>
+      <dc:identifier>WP00193065</dc:identifier>
       <ebu:attributor>
         <ebu:organisationDetails>
           <ebu:organisationName>WON</ebu:organisationName>
         </ebu:organisationDetails>
       </ebu:attributor>
     </ebu:identifier>
-    <ebu:identifier typeDefinition="historicalRecordNumber">
-      <dc:identifier />
-    </ebu:identifier>
     <ebu:identifier formatLanguage="NL" typeDefinition="otIdOpen">
-      <dc:identifier />
+      <dc:identifier/>
     </ebu:identifier>
-    <ebu:relation internalRunningOrderNumber="6" typeDefinition="season" />
+    <ebu:relation internalRunningOrderNumber="54" typeDefinition="season"/>
     <ebu:relation typeDefinition="season">
       <ebu:relationIdentifier>
-        <dc:identifier>4488222529</dc:identifier>
+        <dc:identifier>982964902527</dc:identifier>
       </ebu:relationIdentifier>
     </ebu:relation>
     <ebu:rights>
       <ebu:rightsHolder>
         <ebu:organisationDetails>
-          <ebu:organisationName />
+          <ebu:organisationName>niet VRT</ebu:organisationName>
         </ebu:organisationDetails>
       </ebu:rightsHolder>
     </ebu:rights>
+    <ebu:publicationHistory>
+      <ebu:publicationEvent>
+        <ebu:publicationDate>2021-02-18</ebu:publicationDate>
+        <ebu:publicationTime>00:00:00</ebu:publicationTime>
+        <ebu:publicationChannel typeDefinition="VRTNU" typeLabel="Onbepaald"/>
+      </ebu:publicationEvent>
+    </ebu:publicationHistory>
   </viaa:metadata>
 </viaa:getMetadataResponse>

--- a/tests/resources/getMetadataResponseWithSubtitles.xml
+++ b/tests/resources/getMetadataResponseWithSubtitles.xml
@@ -1,106 +1,106 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<viaa:getMetadataResponse xmlns:viaa="http://www.vrt.be/mig/viaa/api" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ns4="http://www.vrt.be/mig/viaa">
-  <viaa:correlationId>WP00026602</viaa:correlationId>
+<viaa:getMetadataResponse xmlns:viaa="http://www.vrt.be/mig/viaa/api"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012"
+  xmlns:ns4="http://www.vrt.be/mig/viaa">
+  <viaa:timestamp>2021-02-13T22:40:46.020+01:00</viaa:timestamp>
+  <viaa:correlationId>WP00192820</viaa:correlationId>
   <viaa:status>SUCCESS</viaa:status>
   <viaa:metadata>
     <ebu:title>
-      <dc:title>Witse R004 A0006</dc:title>
+      <dc:title>Waar is Mark? R001 A0001</dc:title>
     </ebu:title>
     <ebu:alternativeTitle>
-      <dc:title>Duivelskoppel</dc:title>
+      <dc:title>Waar is Mark?</dc:title>
     </ebu:alternativeTitle>
     <ebu:alternativeTitle typeDefinition="season">
-      <dc:title>Witse R004</dc:title>
+      <dc:title>Waar is Mark? R001</dc:title>
     </ebu:alternativeTitle>
     <ebu:alternativeTitle typeDefinition="series">
-      <dc:title>Witse</dc:title>
+      <dc:title>Waar is Mark?</dc:title>
     </ebu:alternativeTitle>
     <ebu:alternativeTitle typeDefinition="program">
-      <dc:title>Witse R004 A0006</dc:title>
+      <dc:title>Waar is Mark? R001 A0001</dc:title>
     </ebu:alternativeTitle>
     <ebu:creator>
       <ebu:organisationDetails>
         <ebu:organisationName>TV</ebu:organisationName>
       </ebu:organisationDetails>
-      <ebu:role typeDefinition="productionCompany" />
+      <ebu:role typeDefinition="productionCompany"/>
     </ebu:creator>
     <ebu:creator>
       <ebu:organisationDetails>
-        <ebu:organisationName />
+        <ebu:organisationName/>
       </ebu:organisationDetails>
-      <ebu:role typeDefinition="provenance" />
+      <ebu:role typeDefinition="provenance"/>
     </ebu:creator>
-    <ebu:subject note="" />
+    <ebu:subject note=""/>
     <ebu:description typeDefinition="short">
-      <dc:description>Vlaamse misdaadserie rond een eigenzinnige en gedreven speurder bij de Federale Recherche in Halle.</dc:description>
+      <dc:description>Humaninterestprogramma waarin reporter Lidewij Nuitten op zoek gaat naar haar eerste jeugdliefde: een zwarte jongen met de naam Mark.</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="long">
-      <dc:description>De rijke barones Van Calster wordt bij een inbraak vermoord, maar vreemd genoeg worden maar weinig zaken gestolen in haar kasteel. De barones had een veel jongere minnaar, de zogezegde landjonker Hendrik Palfijn, en leefde in onmin met haar zoon Didier. Beide mannen azen op het bezit van de barone, en delen een interesse in Sylvia, een model uit het Oostblok dat het in het Westen wil 'maken'.</dc:description>
+      <dc:description>Lidewij keert terug naar de plek waar ze twintig jaar geleden tijdens een sportkamp verliefd werd. Met de weinige info die ze heeft, start ze haar zoektocht naar een geadopteerde jongen die Mark heet en vermoedelijk in de Kempen woont. Ze komt terecht bij een Marc uit Haïti en een Mark uit Rwanda. Is een van hen de jongen waar ze als kind verliefd op werd? Uit de verschillende gesprekken die Lidewij voert, blijkt ook dat adopties in de jaren 80 en 90 niet altijd zo zuiver verliepen.</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="season">
-      <dc:description>4</dc:description>
+      <dc:description>1</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="comment">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="cast">
-      <dc:description>
-        Met: Hubert Damen (Witse), Inge Paulussen (Sam Deconinck), Daan Hugaert (Romain Van Deun), Marc Stroobants (Rudy Dams), Dirk Tuypens (Peter Wijtinckx), Els Olaerts (Annemie Nachtegaele) e.a.
-        Gastacteurs: Katelijne Verbeke (Dokter Véronique Maes), Roel Vanderstukken (Kris), Kristine Van Pellicom (Hazel Ruysselede), Rita Smets (Angèle Van Calster), Gene Bervoets (Hendrik Palfijn), Robert De La Haye (Didier Van Calster) e.a.
-      </dc:description>
+      <dc:description>Lidewij Nuitten</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="category">
       <dc:description>algemeen</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="categoryTrailer">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="productionMethod">
       <dc:description>intern</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="status">
-      <dc:description>gearchiveerd</dc:description>
+      <dc:description>nieuw</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="cleanMediaVersion">
-      <dc:description>0</dc:description>
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="hasBeenBroadcasted">
-      <dc:description>true</dc:description>
+      <dc:description>false</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="contentCheck">
       <dc:description>false</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="historicalFormat">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="duration">
-      <dc:description>00:55:14:00</dc:description>
+      <dc:description>00:37:37:18</dc:description>
     </ebu:description>
     <ebu:description typeDefinition="rights">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:description typeDefinition="rightsType">
-      <dc:description />
+      <dc:description/>
     </ebu:description>
     <ebu:publisher>
       <ebu:organisationDetails>
-        <ebu:organisationName />
+        <ebu:organisationName/>
       </ebu:organisationDetails>
-      <ebu:role typeDefinition="publisher" />
+      <ebu:role typeDefinition="publisher"/>
     </ebu:publisher>
     <ebu:date>
-      <ebu:created />
-      <ebu:alternative startDate="2020-08-04" startTime="00:00:00" typeDefinition="mainDate" />
+      <ebu:created/>
     </ebu:date>
     <ebu:type>
-      <ebu:genre typeDefinition="fictie" />
-      <ebu:objectType typeDefinition="program" />
+      <ebu:genre typeDefinition="magazine"/>
+      <ebu:objectType typeDefinition="program"/>
     </ebu:type>
     <ebu:format formatDefinition="current">
       <ebu:videoFormat videoFormatDefinition="hires">
         <ebu:width>1920</ebu:width>
         <ebu:height>1080</ebu:height>
-        <ebu:frameRate>25</ebu:frameRate>
+        <ebu:frameRate factorDenominator="1" factorNumerator="25">25</ebu:frameRate>
         <ebu:aspectRatio>
           <ebu:factorNumerator>16</ebu:factorNumerator>
           <ebu:factorDenominator>9</ebu:factorDenominator>
@@ -108,22 +108,22 @@
         <ebu:codec>
           <ebu:name>AVC-I</ebu:name>
         </ebu:codec>
-        <ebu:bitRate>113664000</ebu:bitRate>
+        <ebu:bitRate>100000000</ebu:bitRate>
       </ebu:videoFormat>
-      <ebu:containerFormat formatDefinition="MXF OP1a" />
+      <ebu:containerFormat formatDefinition="MXF OP1a"/>
       <ebu:start>
-        <ebu:timecode>00:03:00:00</ebu:timecode>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
       </ebu:start>
       <ebu:end>
-        <ebu:timecode>00:58:14:00</ebu:timecode>
+        <ebu:timecode>10:37:37:18</ebu:timecode>
       </ebu:end>
-      <ebu:technicalAttributeString typeDefinition="SOM">00:03:00:00</ebu:technicalAttributeString>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
     </ebu:format>
     <ebu:format formatDefinition="current">
       <ebu:videoFormat videoFormatDefinition="lores">
         <ebu:width>1280</ebu:width>
         <ebu:height>720</ebu:height>
-        <ebu:frameRate>25</ebu:frameRate>
+        <ebu:frameRate factorDenominator="1" factorNumerator="25">25</ebu:frameRate>
         <ebu:aspectRatio>
           <ebu:factorNumerator>16</ebu:factorNumerator>
           <ebu:factorDenominator>9</ebu:factorDenominator>
@@ -131,44 +131,72 @@
         <ebu:codec>
           <ebu:name>H264</ebu:name>
         </ebu:codec>
-        <ebu:bitRate>2106680</ebu:bitRate>
+        <ebu:bitRate>1683048</ebu:bitRate>
       </ebu:videoFormat>
-      <ebu:containerFormat formatDefinition="MP4" />
+      <ebu:containerFormat formatDefinition="MP4"/>
       <ebu:start>
-        <ebu:timecode>00:03:00:00</ebu:timecode>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
       </ebu:start>
       <ebu:end>
-        <ebu:timecode>00:58:14:00</ebu:timecode>
+        <ebu:timecode>10:37:37:18</ebu:timecode>
       </ebu:end>
-      <ebu:technicalAttributeString typeDefinition="SOM">00:03:00:00</ebu:technicalAttributeString>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
     </ebu:format>
+    <ebu:format formatDefinition="current">
+      <ebu:dataFormat>
+        <ebu:captioningFormat formatDefinition="open" language="nl"/>
+      </ebu:dataFormat>
+      <ebu:start>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
+      </ebu:start>
+      <ebu:end>
+        <ebu:timecode>10:37:37:18</ebu:timecode>
+      </ebu:end>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
+      <ebu:dateCreated startDate="2021-02-11" startTime="12:25:49"/>
+      <ebu:dateModified startDate="2021-02-12" startTime="15:18:57"/>
+    </ebu:format>
+    <ebu:format formatDefinition="current">
+      <ebu:dataFormat>
+        <ebu:captioningFormat formatDefinition="closed" language="nl"/>
+      </ebu:dataFormat>
+      <ebu:start>
+        <ebu:timecode>10:00:00:00</ebu:timecode>
+      </ebu:start>
+      <ebu:end>
+        <ebu:timecode>10:37:37:18</ebu:timecode>
+      </ebu:end>
+      <ebu:technicalAttributeString typeDefinition="SOM">10:00:00:00</ebu:technicalAttributeString>
+      <ebu:dateCreated startDate="2021-02-11" startTime="12:24:34"/>
+      <ebu:dateModified startDate="2021-02-11" startTime="12:24:38"/>
+    </ebu:format>
+    <ebu:identifier typeDefinition="historicalRecordNumber">
+      <dc:identifier/>
+    </ebu:identifier>
     <ebu:identifier typeDefinition="MEDIA_ID">
-      <dc:identifier>WP00026602</dc:identifier>
+      <dc:identifier>WP00192820</dc:identifier>
       <ebu:attributor>
         <ebu:organisationDetails>
           <ebu:organisationName>WON</ebu:organisationName>
         </ebu:organisationDetails>
       </ebu:attributor>
     </ebu:identifier>
-    <ebu:identifier typeDefinition="historicalRecordNumber">
-      <dc:identifier />
-    </ebu:identifier>
     <ebu:identifier formatLanguage="NL" typeDefinition="otIdOpen">
-      <dc:identifier />
+      <dc:identifier/>
     </ebu:identifier>
     <ebu:identifier formatLanguage="NL" typeDefinition="otIdClosed">
-      <dc:identifier />
+      <dc:identifier/>
     </ebu:identifier>
-    <ebu:relation internalRunningOrderNumber="6" typeDefinition="season" />
+    <ebu:relation internalRunningOrderNumber="1" typeDefinition="season"/>
     <ebu:relation typeDefinition="season">
       <ebu:relationIdentifier>
-        <dc:identifier>4488222529</dc:identifier>
+        <dc:identifier>979806180527</dc:identifier>
       </ebu:relationIdentifier>
     </ebu:relation>
     <ebu:rights>
       <ebu:rightsHolder>
         <ebu:organisationDetails>
-          <ebu:organisationName />
+          <ebu:organisationName/>
         </ebu:organisationDetails>
       </ebu:rightsHolder>
     </ebu:rights>


### PR DESCRIPTION
 VRT has fixed the issue on their side, so there's no reason anymore for `timestamp` to be optional. 