### PR TITLE
DEV-1617 Retry get items

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ python-json-logger==0.1.11
 PyYAML==5.3.1
 regex==2020.5.14
 requests==2.23.0
+retry==0.9.2
 six==1.15.0
 structlog==20.1.0
 toml==0.10.1

--- a/tests/resources/mocks.py
+++ b/tests/resources/mocks.py
@@ -28,9 +28,13 @@ def mock_mediahaven(mocker):
         print(f"Initiating MH Client.")
         pass
 
+    def mock_get_fragment(self, query_key, value):
+        return { "TotalNrOfResults": 0 }
+
     from app.services.mediahaven import MediahavenClient
 
     mocker.patch.object(MediahavenClient, "__init__", mock_init)
+    mocker.patch.object(MediahavenClient, "get_fragment", mock_get_fragment)
 
 
 @pytest.fixture


### PR DESCRIPTION
Add retry logic for `_get_items_for_media_id` function with [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) by using the [`retry` package](https://github.com/invl/retry). 
Add test for retry logic. 